### PR TITLE
feat: search bar highlights nodes

### DIFF
--- a/src/GraphManager/GraphManager.test.tsx
+++ b/src/GraphManager/GraphManager.test.tsx
@@ -4,7 +4,9 @@ import { GraphManager } from "./GraphManager";
 import { act } from "react-dom/test-utils";
 
 jest.mock("./GraphRenderer", () => {
-  return { GraphRenderer: () => <div></div> };
+  return {
+    GraphRenderer: () => <div></div>,
+  };
 });
 jest.mock("./components/GraphFileList");
 jest.mock("./components/GraphManagementMenu", () => {
@@ -14,7 +16,7 @@ jest.mock("./components/GraphManagementMenu", () => {
 });
 jest.mock("./components/VoteDialog");
 
-describe("GraphManager", () => {
+describe("understanding of jest", () => {
   test("my understanding of jest&react testing/matching", () => {
     const Hello = () => (
       <div>
@@ -25,7 +27,6 @@ describe("GraphManager", () => {
     expect(screen.getByText("Hello").textContent).toEqual("Hello world");
     expect(screen.getByText("world").textContent).toEqual("world");
   });
-
   test("my understanding of jest.fn", () => {
     let useQueryMock = jest.fn();
     useQueryMock.mockReturnValue({
@@ -37,35 +38,39 @@ describe("GraphManager", () => {
   });
 });
 
-describe("opening/closing of edit menu", () => {
-  it("should initially be closed", () => {
-    render(
-      <GraphManager
-        datasets={[{ dataSetName: "mockSEt", data: { nodes: [], links: [] } }]}
-        // @ts-ignore
-        fetchedGraph={undefined}
-        queryResponse={{}}
-      />
-    );
-    expect(screen.queryByTestId("GMM")).not.toBeInTheDocument();
-  });
-  it("should be opened & closed after button click", () => {
-    render(
-      <GraphManager
-        datasets={[{ dataSetName: "mockSEt", data: { nodes: [], links: [] } }]}
-        // @ts-ignore
-        fetchedGraph={undefined}
-        queryResponse={{}}
-      />
-    );
-    const button = screen.queryByLabelText("toggle menu");
-    act(() => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+describe("GraphManager", () => {
+  describe("opening/closing of edit menu", () => {
+    it("should initially be closed", () => {
+      render(
+        <GraphManager
+          datasets={[
+            { dataSetName: "mockSet", data: { nodes: [], links: [] } },
+          ]}
+          fetchedGraph={undefined}
+          queryResponse={{}}
+        />
+      );
+      expect(screen.queryByTestId("GMM")).not.toBeInTheDocument();
     });
-    expect(screen.getByTestId("GMM")).toBeInTheDocument();
-    act(() => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    it("should be opened & closed after button click", () => {
+      render(
+        <GraphManager
+          datasets={[
+            { dataSetName: "mockSet", data: { nodes: [], links: [] } },
+          ]}
+          fetchedGraph={undefined}
+          queryResponse={{}}
+        />
+      );
+      const button = screen.queryByLabelText("toggle menu");
+      act(() => {
+        button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(screen.getByTestId("GMM")).toBeInTheDocument();
+      act(() => {
+        button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(screen.queryByTestId("GMM")).not.toBeInTheDocument();
     });
-    expect(screen.queryByTestId("GMM")).not.toBeInTheDocument();
   });
 });

--- a/src/GraphManager/GraphRenderer.test.tsx
+++ b/src/GraphManager/GraphRenderer.test.tsx
@@ -52,7 +52,7 @@ describe("onLinkClickFn", () => {
       openVoteDialog: jest.fn(),
       selectedGraphDataset: { dataSetName: "", data: { nodes: [], links: [] } },
     };
-    const onLinkClick = onLinkClickFn(props);
+    const onLinkClick = onLinkClickFn(props.openVoteDialog);
     const link = {
       source: "A",
       target: "B",
@@ -91,7 +91,7 @@ describe("nodeCanvasObject", () => {
     ctx.measureText.mockReturnValue({ width: 100 });
     const scale = 1;
     // @ts-ignore
-    nodeCanvasObject(node, ctx, scale);
+    nodeCanvasObject(node, ctx, scale, new Set());
     expect(ctx.font).toEqual("22px Sans-Serif");
     expect(ctx.textAlign).toEqual("center");
     expect(ctx.textBaseline).toEqual("middle");

--- a/src/GraphManager/components/Search.test.tsx
+++ b/src/GraphManager/components/Search.test.tsx
@@ -1,0 +1,32 @@
+import { userSearchMatching } from "./Search";
+import { Node } from "GraphManager/GraphRenderer";
+
+describe("userSearchMatching", () => {
+  it("should do nothing on an empty highlight set", () => {
+    let highlight = new Set<Node>();
+    let graphData = { nodes: [{ id: "1", description: "A" }], links: [] };
+    let userInput = "";
+    userSearchMatching(highlight, graphData, userInput);
+    expect(highlight.size).toBe(0);
+  });
+  it("should match substring and clear after call without match", () => {
+    let highlight = new Set<Node>();
+    let A = { id: "A", description: "XYabcZ" };
+    let graphData = { nodes: [A], links: [] };
+    let userInput = "abc";
+    userSearchMatching(highlight, graphData, userInput);
+    expect(highlight.size).toBe(1);
+    expect(highlight.values().next()).toEqual({ done: false, value: A });
+    userSearchMatching(highlight, graphData, "def");
+    expect(highlight.size).toBe(0);
+  });
+  it("should match case-insensitive", () => {
+    let highlight = new Set<Node>();
+    let A = { id: "A", description: "XYabcZ" };
+    let graphData = { nodes: [A], links: [] };
+    let userInput = "xyA";
+    userSearchMatching(highlight, graphData, userInput);
+    expect(highlight.size).toBe(1);
+    expect(highlight.values().next()).toEqual({ done: false, value: A });
+  });
+});

--- a/src/GraphManager/components/Search.tsx
+++ b/src/GraphManager/components/Search.tsx
@@ -1,0 +1,17 @@
+import { Node, GraphDataForceGraph } from "GraphManager/GraphRenderer";
+
+export const userSearchMatching = (
+  highlightNodes: Set<Node>,
+  graphDataForRender: GraphDataForceGraph,
+  userInput: string
+) => {
+  if (!userInput) {
+    return;
+  }
+  highlightNodes.clear();
+  graphDataForRender.nodes
+    .filter((node) =>
+      node.description.toLowerCase().includes(userInput.toLowerCase())
+    )
+    .forEach((node) => highlightNodes.add(node));
+};

--- a/src/GraphManager/components/SearchAppBar.test.tsx
+++ b/src/GraphManager/components/SearchAppBar.test.tsx
@@ -10,10 +10,9 @@ describe("SearchAppBar", () => {
     let input = screen.getByLabelText("search bar");
     const user = userEvent.setup();
     await user.click(input);
-    await user.keyboard("lol");
-    expect(userInputCallback.mock.calls.length).toBe(3);
-    expect(userInputCallback.mock.calls[0][0]).toEqual("l");
-    expect(userInputCallback.mock.calls[1][0]).toEqual("lo");
-    expect(userInputCallback.mock.calls[2][0]).toEqual("lol");
+    await user.keyboard("1234");
+    expect(userInputCallback.mock.calls.length).toBe(2);
+    expect(userInputCallback.mock.calls[0][0]).toEqual("123");
+    expect(userInputCallback.mock.calls[1][0]).toEqual("1234");
   });
 });

--- a/src/GraphManager/components/SearchAppBar.tsx
+++ b/src/GraphManager/components/SearchAppBar.tsx
@@ -49,11 +49,20 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
   },
 }));
 
-interface SearchAppBarProps {
-  userInputCallback: (query: string) => void;
+export interface SearchCallback {
+  (query: string): void;
 }
 
-export default function SearchAppBar({ userInputCallback }: SearchAppBarProps) {
+interface SearchAppBarProps {
+  userInputCallback: SearchCallback;
+}
+
+export default function SearchAppBar(props: SearchAppBarProps) {
+  const callCallbackIfMoreThan3Chars = (userInput: string) => {
+    if (userInput.length >= 3) {
+      props.userInputCallback(userInput);
+    }
+  };
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
@@ -74,8 +83,7 @@ export default function SearchAppBar({ userInputCallback }: SearchAppBarProps) {
               placeholder="Search…"
               inputProps={{ "aria-label": "search bar" }}
               onChange={(event) => {
-                //console.log(`search input: ${event.target.value}`)
-                userInputCallback(event.target.value);
+                callCallbackIfMoreThan3Chars(event.target.value);
               }}
             />
           </Search>


### PR DESCRIPTION
Highlighting matches based on case-insensitive substring search.

Note: once the simmulation stop, it appears to stop working, since node-canvases are not updated any more.
TODO: find a way to `d3ReheatSimulation` without causing constant chaos.