### PR TITLE
feat: link menu on drag end

### DIFF
--- a/src/GraphManager/GraphEdit.tsx
+++ b/src/GraphManager/GraphEdit.tsx
@@ -246,13 +246,16 @@ export const openCreateLinkPopUp = (
       return;
     }
     const linkID = result.data!.createEdge.ID;
-    if (!!conf?.updateExistingLink) {
+    if (!!conf?.updateExistingLink && form.sourceNode === conf.updateExistingLink.source.id && form.targetNode === conf.updateExistingLink.target.id) {
       ctrl.graph.updateLink(conf.updateExistingLink, {
         ...conf.updateExistingLink,
         value: form.linkWeight,
         id: linkID,
       });
     } else {
+      if (!!conf?.updateExistingLink) {
+        ctrl.graph.removeLink(conf.updateExistingLink);
+      }
       const link: ForceGraphLinkObjectInitial = {
         id: linkID,
         source: form.sourceNode,

--- a/src/GraphManager/GraphEditCreateButton.tsx
+++ b/src/GraphManager/GraphEditCreateButton.tsx
@@ -48,7 +48,7 @@ export const CreateButton = ({ ctrl }: CreateButtonProps) => {
           ctrl,
         );
       case "newLink":
-        return openCreateLinkPopUp(ctrl);
+        return openCreateLinkPopUp(ctrl, undefined);
     }
   };
 

--- a/src/GraphManager/GraphEditPopUp.test.tsx
+++ b/src/GraphManager/GraphEditPopUp.test.tsx
@@ -1,3 +1,4 @@
+import { INTERIM_TMP_LINK_ID } from "./GraphEdit";
 import { isValidNodeForLink, nodeValidation } from "./GraphEditPopUp";
 import { ForceGraphNodeObject } from "./types";
 //import { LinkCreatePopUp, GraphEditPopUp } from "./GraphEditPopUp";
@@ -101,6 +102,24 @@ describe("isValidNodeForLink", () => {
     isValid.createError = (args) => args;
     // @ts-ignore
     expect(() => isValid.test("1")).toThrow("self-linking is not allowed");
+  });
+  it("should ignore a temporary existing link", () => {
+    // @ts-ignore
+    const [n1, n2]: ForceGraphNodeObject[] = [{ id: "1" }, { id: "2" }];
+    const isValid = isValidNodeForLink({
+      nodes: [n1, n2],
+      links: [{ id: INTERIM_TMP_LINK_ID, source: n1, target: n2, value: 5 }],
+    });
+    // @ts-ignore
+    isValid.parent = {
+      sourceNode: "1",
+      targetNode: "2",
+      linkWeight: 5,
+    };
+    // @ts-ignore
+    isValid.createError = (args) => args;
+    // @ts-ignore
+    expect(isValid.test("1")).toBe(true);
   });
 });
 

--- a/src/GraphManager/components/LoginManager/Styles.tsx
+++ b/src/GraphManager/components/LoginManager/Styles.tsx
@@ -1,6 +1,6 @@
 import { Box, styled, TextField } from "@mui/material";
 import { FormikValues, useFormik } from "formik";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Autocomplete from "@mui/material/Autocomplete";
 
 export const StyledBox = styled(Box)(() => ({
@@ -63,6 +63,14 @@ export const TextFieldFormikGeneratorAutocomplete = (
     setSelectedOption(option);
     conf.formik.setFieldValue(conf.fieldName, conf.optionValue(option));
   };
+  useEffect(() => {
+    if (!!conf.defaultValue) {
+      handleInputChange(null, conf.defaultValue);
+    }
+    // NOTE: handleInputChange changes when called, thus adding it as
+    // dependency would create an infinite loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conf.defaultValue]);
   //const handleKeyDown = (event: any) => {
   //  if (event.key === 'Tab') {
   //    select next entry?
@@ -74,7 +82,7 @@ export const TextFieldFormikGeneratorAutocomplete = (
       getOptionLabel={conf.optionLabel}
       value={selectedOption}
       onChange={handleInputChange}
-      defaultValue={conf.defaultValue}
+      defaultValue={""}
       freeSolo
       renderInput={(params) => (
         <TextField

--- a/src/GraphManager/components/VoteDialog.tsx
+++ b/src/GraphManager/components/VoteDialog.tsx
@@ -90,6 +90,7 @@ export const LinkWeightSlider = (props: LinkWeightSliderProps) => {
     _event: any,
     newValue: Number | Array<Number>,
   ) => {
+    console.log(`settings slider to ${newValue}`);
     props.setSliderValue(newValue);
   };
   // TODO(skep): translations


### PR DESCRIPTION
Opens link menu onNodeDragEnd, i.e. when creating a temporary link by dragging, the normal create-link menu opens.
Previously the link would be immediately created. Now the user can make changes to the link-weight, even change the nodes, if the snapping didn't do what user expected, and even just cancel the link creation.