### PR TITLE
refactor: zoom slider

### DIFF
--- a/src/GraphManager/ZoomControlPanel.test.tsx
+++ b/src/GraphManager/ZoomControlPanel.test.tsx
@@ -91,7 +91,7 @@ describe("makeZoomControl", () => {
       expect(ctrl.zoom.setZoomLevel).toHaveBeenCalledWith(
         ctrl.zoom.zoomLevel + 2,
       );
-      expect(ctrl.zoom.setZoomStepStack).toHaveBeenCalledTimes(2);
+      expect(ctrl.zoom.setZoomStepStack).toHaveBeenCalledTimes(1);
     });
     it("should cap zoom at MAX", () => {
       // @ts-ignore
@@ -102,6 +102,27 @@ describe("makeZoomControl", () => {
       // @ts-ignore
       zoomCtrl.onZoomChange(ZOOM_LEVEL_MIN - 1);
       expect(ctrl.zoom.setZoomLevel).toHaveBeenCalledWith(ZOOM_LEVEL_MIN);
+    });
+    it("should skip calls with invalid diff", () => {
+      ctrl.zoom.zoomLevel = ZOOM_LEVEL_MAX;
+      zoomCtrl.onZoomChange(ZOOM_LEVEL_MAX - 1);
+      expect(ctrl.zoom.setZoomLevel).toHaveBeenCalledTimes(1);
+      expect(ctrl.zoom.setZoomLevel).toHaveBeenNthCalledWith(
+        1,
+        ZOOM_LEVEL_MAX - 1,
+      );
+      expect(ctrl.zoom.zoomStepStack).toEqual([1]);
+      // second call comes so quick, that zoomLevel did not change yet!
+      ctrl.zoom.zoomLevel = ZOOM_LEVEL_MAX;
+      zoomCtrl.onZoomChange(ZOOM_LEVEL_MAX - 2);
+      expect(ctrl.zoom.setZoomLevel).toHaveBeenCalledTimes(2);
+      expect(ctrl.zoom.setZoomLevel).toHaveBeenNthCalledWith(
+        2,
+        ZOOM_LEVEL_MAX - 2,
+      );
+      // should only push one value to the stack, even though diff between
+      // zoomLevel and newZoomLevel = 2
+      expect(ctrl.zoom.zoomStepStack).toEqual([1, 1]);
     });
   });
 });

--- a/src/GraphManager/ZoomControlPanel.tsx
+++ b/src/GraphManager/ZoomControlPanel.tsx
@@ -42,22 +42,6 @@ export function deduplicateCallsWithSameParameters<T extends any[]>(
   };
 }
 
-let lastInvocationTime: number | null = null;
-// Note: cannot be exported, uses global data, must bypass react-state, since
-// react-state is the source of the problem. Must only be used in one location.
-const limitCallsPerSecond = (callback: AnyFunction, callsPerSecond: number) => {
-  return (...args: any[]) => {
-    const currentTime = Date.now();
-    if (
-      !lastInvocationTime ||
-      currentTime - lastInvocationTime >= 1000 / callsPerSecond
-    ) {
-      callback(...args);
-      lastInvocationTime = currentTime;
-    }
-  };
-};
-
 export const makeZoomControl = (ctrl: Controller) => {
   let state = {
     zoomSteps: ctrl.zoom.zoomState.zoomSteps,
@@ -172,10 +156,10 @@ export const ZoomControlPanel = ({ zoomControl }: ZoomControlPanelProps) => {
       </IconButton>
       <Slider
         value={zoomControl.zoomLevel}
-        onChange={(_: Event, tmpLevel: number | number[]) => {
-          // @ts-ignore: it's a number - always.
-          let level: number = tmpLevel;
-          return limitCallsPerSecond(zoomControl.onZoomChange, 5)(level);
+        onChange={(_: Event, _tmpLevel: number | number[]) => {
+          //// @ts-ignore: it's a number - always.
+          //let level: number = tmpLevel;
+          //return limitCallsPerSecond(zoomControl.onZoomChange, 5)(level);
         }}
         min={ZOOM_LEVEL_MIN}
         max={ZOOM_LEVEL_MAX}

--- a/src/GraphManager/ZoomControlPanel.tsx
+++ b/src/GraphManager/ZoomControlPanel.tsx
@@ -157,9 +157,10 @@ export const ZoomControlPanel = ({ zoomControl }: ZoomControlPanelProps) => {
       <Slider
         value={zoomControl.zoomLevel}
         onChange={(_: Event, _tmpLevel: number | number[]) => {
+          // XXX(skep): temporarily disabled, since usage leads to display bug
           //// @ts-ignore: it's a number - always.
           //let level: number = tmpLevel;
-          //return limitCallsPerSecond(zoomControl.onZoomChange, 5)(level);
+          //return zoomControl.onZoomChange(level);
         }}
         min={ZOOM_LEVEL_MIN}
         max={ZOOM_LEVEL_MAX}

--- a/src/GraphManager/ZoomControlPanel.tsx
+++ b/src/GraphManager/ZoomControlPanel.tsx
@@ -27,24 +27,56 @@ export function debounce<Func extends AnyFunction>(func: Func, delay: number) {
     }, delay);
   };
 }
+export function deduplicateCallsWithSameParameters<T extends any[]>(
+  callback: AnyFunction,
+): AnyFunction {
+  let lastArgs: any[] | null = null;
+  return (...args: T) => {
+    if (
+      !lastArgs ||
+      !args.every((value, index) => value === lastArgs![index])
+    ) {
+      callback(...args);
+      lastArgs = [...args];
+    }
+  };
+}
+
+let lastInvocationTime: number | null = null;
+// Note: cannot be exported, uses global data, must bypass react-state, since
+// react-state is the source of the problem. Must only be used in one location.
+const limitCallsPerSecond = (callback: AnyFunction, callsPerSecond: number) => {
+  return (...args: any[]) => {
+    const currentTime = Date.now();
+    if (
+      !lastInvocationTime ||
+      currentTime - lastInvocationTime >= 1000 / callsPerSecond
+    ) {
+      callback(...args);
+      lastInvocationTime = currentTime;
+    }
+  };
+};
 
 export const makeZoomControl = (ctrl: Controller) => {
   let state = {
     zoomSteps: ctrl.zoom.zoomState.zoomSteps,
     graphData: ctrl.graph.current,
   };
-  const performZoomIn = () => {
-    const n = ctrl.zoom.zoomStepStack.pop();
+  const setZoomState = () => {
     ctrl.zoom.setZoomStepStack(ctrl.zoom.zoomStepStack);
-    if (!n) {
-      return;
-    }
-    for (let i = 0; i < n; i++) {
-      zoomStep({ direction: ZoomDirection.In, steps: 1 }, state);
-    }
     ctrl.zoom.setZoomState(state);
     uglyHack(ctrl);
     ctrl.forceGraphRef.current?.d3ReheatSimulation();
+  };
+  const performZoomIn = () => {
+    const n = ctrl.zoom.zoomStepStack.pop();
+    if (!n) {
+      return;
+    }
+    for (let i = 0; i <= n; i++) {
+      zoomStep({ direction: ZoomDirection.In, steps: 1 }, state);
+    }
   };
   const onZoomIn = () => {
     if (ctrl.zoom.zoomLevel >= ZOOM_LEVEL_MAX) {
@@ -52,17 +84,14 @@ export const makeZoomControl = (ctrl: Controller) => {
     }
     ctrl.zoom.setZoomLevel(ctrl.zoom.zoomLevel + ZOOM_LEVEL_STEP);
     performZoomIn();
+    setZoomState();
   };
   const performZoomOut = () => {
-    const n = ctrl.graph.current.nodes.length / 2;
+    const n = Math.abs(ctrl.graph.current.nodes.length / 2);
     ctrl.zoom.zoomStepStack.push(n);
-    ctrl.zoom.setZoomStepStack(ctrl.zoom.zoomStepStack);
-    for (let i = 0; i < n; i++) {
+    for (let i = 0; i <= n; i++) {
       zoomStep({ direction: ZoomDirection.Out, steps: 1 }, state);
     }
-    ctrl.zoom.setZoomState(state);
-    uglyHack(ctrl);
-    ctrl.forceGraphRef.current?.d3ReheatSimulation();
   };
   const onZoomOut = () => {
     if (ctrl.zoom.zoomLevel <= ZOOM_LEVEL_MIN) {
@@ -70,34 +99,54 @@ export const makeZoomControl = (ctrl: Controller) => {
     }
     ctrl.zoom.setZoomLevel(ctrl.zoom.zoomLevel - ZOOM_LEVEL_STEP);
     performZoomOut();
+    setZoomState();
   };
+  // Note: We must remember the last zoom level outside of react state, since
+  // react state performs asynchronous calls, and the slider changes it's value
+  // very rapidly.
+  let lastZoomLevel: number | null = null;
   const onZoomChange = (newValue: number) => {
-    let diff = Math.abs(ctrl.zoom.zoomLevel - newValue);
-    if (ctrl.zoom.zoomLevel < newValue) {
-      if (ctrl.zoom.zoomLevel + diff > ZOOM_LEVEL_MAX) {
-        diff -= ctrl.zoom.zoomLevel + diff - ZOOM_LEVEL_MAX;
-      }
-      ctrl.zoom.setZoomLevel(ctrl.zoom.zoomLevel + diff);
-      for (let i = 0; i < diff; i++) {
-        performZoomIn();
-      }
-    } else {
-      if (ctrl.zoom.zoomLevel - diff < ZOOM_LEVEL_MIN) {
-        diff -= ctrl.zoom.zoomLevel - diff + ZOOM_LEVEL_MIN;
-      }
-      ctrl.zoom.setZoomLevel(ctrl.zoom.zoomLevel - diff);
-      for (let i = 0; i < diff; i++) {
-        performZoomOut();
-      }
+    if (!lastZoomLevel) {
+      lastZoomLevel = ctrl.zoom.zoomLevel;
     }
+    newValue = capInclusive(newValue, {
+      upper: ZOOM_LEVEL_MAX,
+      lower: ZOOM_LEVEL_MIN,
+    });
+    let performZoom: () => void;
+    if (lastZoomLevel < newValue) {
+      performZoom = performZoomIn;
+    } else {
+      performZoom = performZoomOut;
+    }
+    for (let i = 0; i < Math.abs(lastZoomLevel - newValue); i++) {
+      performZoom();
+    }
+    lastZoomLevel = newValue;
+    ctrl.zoom.setZoomLevel(newValue);
+    setZoomState();
   };
   const zoomCtrl: ZoomPanelControl = {
     zoomLevel: ctrl.zoom.zoomLevel,
-    onZoomChange,
+    onZoomChange: deduplicateCallsWithSameParameters(onZoomChange),
     onZoomIn,
     onZoomOut,
   };
   return zoomCtrl;
+};
+
+interface Bound {
+  upper: number;
+  lower: number;
+}
+// capInclusive caps the number n inside the bounaries bound
+const capInclusive = (n: number, bound: Bound) => {
+  if (n > bound.upper) {
+    n = bound.upper;
+  } else if (n < bound.lower) {
+    n = bound.lower;
+  }
+  return n;
 };
 
 export const ZOOM_LEVEL_MIN = 1;
@@ -123,11 +172,10 @@ export const ZoomControlPanel = ({ zoomControl }: ZoomControlPanelProps) => {
       </IconButton>
       <Slider
         value={zoomControl.zoomLevel}
-        onChange={(_: Event, _tmpLevel: number | number[]) => {
-          // XXX(skep): temporarily disabled, since usage leads to display bug
-          //// @ts-ignore: it's a number - always.
-          //let level: number = tmpLevel;
-          //return zoomControl.onZoomChange(level);
+        onChange={(_: Event, tmpLevel: number | number[]) => {
+          // @ts-ignore: it's a number - always.
+          let level: number = tmpLevel;
+          return limitCallsPerSecond(zoomControl.onZoomChange, 5)(level);
         }}
         min={ZOOM_LEVEL_MIN}
         max={ZOOM_LEVEL_MAX}


### PR DESCRIPTION
Just in case we ever want to enable it again, refactor the slider code & fix small things, like de-duplicating consecutive calls with the same parameters.