### PR TITLE
feat: onNodeDrag link-creation improvements

### DIFF
--- a/src/GraphManager/GraphEdit.test.tsx
+++ b/src/GraphManager/GraphEdit.test.tsx
@@ -1,8 +1,8 @@
 import {
-  Backend,
   DEFAULT_EDIT_LINK_WEIGHT,
   DRAG_snapInDistanceSquared,
   DRAG_snapOutDistanceSquared,
+  FG_ENGINE_COOLDOWN_TICKS_DISABLED,
   INTERIM_TMP_LINK_ID,
   NodeDragState,
   onLinkClick,
@@ -14,7 +14,7 @@ import {
 } from "./GraphEdit";
 import { GraphEditPopUpState, NewLinkForm } from "./GraphEditPopUp";
 import { ForceGraphLinkObject } from "./types";
-import { makeMockController, makeGraphState } from "./GraphEdit.testingutil";
+import { makeMockController } from "./GraphEdit.testingutil";
 
 describe("openCreateNodePopUpAtMousePosition", () => {
   const makeMockMouseEvent = (props: any) => {
@@ -120,20 +120,25 @@ describe("onNodeDrag", () => {
   };
   it("should add currently dragged node to NodeDragState, and do nothing else if no other node in range", () => {
     const { node_1, node_2_far } = makeNodes();
-    const nodeDrag = makeNodeDragState({});
-    const graph = makeGraphState();
-    graph.current.nodes = [node_1, node_2_far];
+    const ctrl = makeMockController();
     // @ts-ignore
-    onNodeDrag({ graph, nodeDrag }, node_1, { x: 0, y: 0 });
-    expect(nodeDrag.state).toEqual({ dragSourceNode: node_1 });
+    ctrl.nodeDrag = makeNodeDragState({});
+    ctrl.graph.current.nodes = [node_1, node_2_far];
+    // @ts-ignore
+    onNodeDrag(ctrl, node_1, { x: 0, y: 0 });
+    expect(ctrl.nodeDrag.state).toEqual({ dragSourceNode: node_1 });
+    expect(ctrl.setCooldownTicks).toHaveBeenCalledWith(
+      FG_ENGINE_COOLDOWN_TICKS_DISABLED,
+    );
   });
   it("should add interimLink for in-range node and remove for out-of-range node", () => {
-    const graph = makeGraphState();
+    const ctrl = makeMockController();
     const { node_1, node_3_close } = makeNodes();
-    graph.current.nodes = [node_1, node_3_close];
-    const nodeDrag = makeNodeDragState({ dragSourceNode: node_1 });
+    ctrl.graph.current.nodes = [node_1, node_3_close];
     // @ts-ignore
-    onNodeDrag({ graph, nodeDrag }, node_1, { x: 0, y: 0 });
+    ctrl.nodeDrag = makeNodeDragState({ dragSourceNode: node_1 });
+    // @ts-ignore
+    onNodeDrag(ctrl, node_1, { x: 0, y: 0 });
     const interimLink: ForceGraphLinkObject = {
       id: INTERIM_TMP_LINK_ID,
       source: node_1,
@@ -144,23 +149,24 @@ describe("onNodeDrag", () => {
       dragSourceNode: node_1,
       interimLink: interimLink,
     };
-    expect(nodeDrag.state).toEqual(expDrag);
-    expect(graph.addLink).toHaveBeenCalledTimes(1);
-    expect(graph.addLink).toHaveBeenNthCalledWith(1, interimLink);
-    graph.current.nodes[1].x = Math.sqrt(DRAG_snapOutDistanceSquared) + 1;
+    expect(ctrl.nodeDrag.state).toEqual(expDrag);
+    expect(ctrl.graph.addLink).toHaveBeenCalledTimes(1);
+    expect(ctrl.graph.addLink).toHaveBeenNthCalledWith(1, interimLink);
+    ctrl.graph.current.nodes[1].x = Math.sqrt(DRAG_snapOutDistanceSquared) + 1;
     // @ts-ignore
-    onNodeDrag({ graph, nodeDrag }, node_1, { x: 0, y: 0 });
-    expect(graph.removeLink).toHaveBeenCalledTimes(1);
-    expect(graph.removeLink).toHaveBeenNthCalledWith(1, interimLink);
-    expect(nodeDrag.state).toEqual({ dragSourceNode: node_1 });
+    onNodeDrag(ctrl, node_1, { x: 0, y: 0 });
+    expect(ctrl.graph.removeLink).toHaveBeenCalledTimes(1);
+    expect(ctrl.graph.removeLink).toHaveBeenNthCalledWith(1, interimLink);
+    expect(ctrl.nodeDrag.state).toEqual({ dragSourceNode: node_1 });
   });
   it("should switch interim link if getting close to another node", () => {
-    const graph = makeGraphState();
+    const ctrl = makeMockController();
     const { node_1, node_2_far, node_3_close } = makeNodes();
-    graph.current.nodes = [node_1, node_3_close, node_2_far];
-    const nodeDrag = makeNodeDragState({ dragSourceNode: node_1 });
+    ctrl.graph.current.nodes = [node_1, node_3_close, node_2_far];
     // @ts-ignore
-    onNodeDrag({ graph, nodeDrag }, node_1, { x: 0, y: 0 });
+    ctrl.nodeDrag = makeNodeDragState({ dragSourceNode: node_1 });
+    // @ts-ignore
+    onNodeDrag(ctrl, node_1, { x: 0, y: 0 });
     const interimLink: ForceGraphLinkObject = {
       id: INTERIM_TMP_LINK_ID,
       source: node_1,
@@ -171,12 +177,12 @@ describe("onNodeDrag", () => {
       dragSourceNode: node_1,
       interimLink: interimLink,
     };
-    expect(nodeDrag.state).toEqual(expDrag);
-    expect(graph.addLink).toHaveBeenCalledTimes(1);
-    expect(graph.addLink).toHaveBeenNthCalledWith(1, interimLink);
+    expect(ctrl.nodeDrag.state).toEqual(expDrag);
+    expect(ctrl.graph.addLink).toHaveBeenCalledTimes(1);
+    expect(ctrl.graph.addLink).toHaveBeenNthCalledWith(1, interimLink);
     node_2_far.x = node_3_close.x - 1;
     // @ts-ignore
-    onNodeDrag({ graph, nodeDrag }, node_1, { x: 0, y: 0 });
+    onNodeDrag(ctrl, node_1, { x: 0, y: 0 });
     const interimLink2: ForceGraphLinkObject = {
       id: INTERIM_TMP_LINK_ID,
       source: node_1,
@@ -187,16 +193,16 @@ describe("onNodeDrag", () => {
       dragSourceNode: node_1,
       interimLink: interimLink2,
     };
-    expect(nodeDrag.state).toEqual(expDrag2);
-    expect(graph.removeLink).toHaveBeenCalledTimes(1);
-    expect(graph.removeLink).toHaveBeenNthCalledWith(1, interimLink);
-    expect(graph.addLink).toHaveBeenCalledTimes(2);
-    expect(graph.addLink).toHaveBeenNthCalledWith(2, interimLink2);
+    expect(ctrl.nodeDrag.state).toEqual(expDrag2);
+    expect(ctrl.graph.removeLink).toHaveBeenCalledTimes(1);
+    expect(ctrl.graph.removeLink).toHaveBeenNthCalledWith(1, interimLink);
+    expect(ctrl.graph.addLink).toHaveBeenCalledTimes(2);
+    expect(ctrl.graph.addLink).toHaveBeenNthCalledWith(2, interimLink2);
   });
   it("should not remove links where the source node, is not the currently dragged one", () => {
-    const graph = makeGraphState();
+    const ctrl = makeMockController();
     const { node_1, node_2_far, node_3_close, node_4_far } = makeNodes();
-    graph.current.nodes = [node_1, node_4_far, node_3_close, node_2_far];
+    ctrl.graph.current.nodes = [node_1, node_4_far, node_3_close, node_2_far];
     const link_12 = { id: "1", source: node_1, target: node_2_far, value: 5 };
     const link_42 = {
       id: INTERIM_TMP_LINK_ID,
@@ -204,35 +210,26 @@ describe("onNodeDrag", () => {
       target: node_2_far,
       value: DEFAULT_EDIT_LINK_WEIGHT,
     };
-    graph.current.links = [link_12, link_42];
-    const nodeDrag = makeNodeDragState({
+    ctrl.graph.current.links = [link_12, link_42];
+    // @ts-ignore
+    ctrl.nodeDrag = makeNodeDragState({
       dragSourceNode: node_4_far,
       interimLink: link_42,
     });
     // @ts-ignore
-    onNodeDrag({ graph, nodeDrag }, node_1, { x: 0, y: 0 });
-    expect(graph.removeLink).toHaveBeenCalledTimes(1);
-    expect(graph.removeLink).toHaveBeenNthCalledWith(1, link_42);
+    onNodeDrag(ctrl, node_1, { x: 0, y: 0 });
+    expect(ctrl.graph.removeLink).toHaveBeenCalledTimes(1);
+    expect(ctrl.graph.removeLink).toHaveBeenNthCalledWith(1, link_42);
   });
 });
 
 describe("onNodeDragEnd", () => {
-  const makeBackend = () => {
-    const ctrl = makeMockController();
-    const b: Backend = ctrl.backend;
-    return b;
-  };
   it("shoud do nothing if no interimLink exists", () => {
-    const graph = makeGraphState();
-    const nodeDrag: NodeDragState = {};
-    const backend = makeBackend();
-    onNodeDragEnd(
-      // @ts-ignore
-      { backend, graph, nodeDrag: { state: nodeDrag, setState: jest.fn() } },
-      { id: "idk", description: "ok" },
-      { x: 0, y: 0 },
-    );
-    expect(backend.createLink).not.toHaveBeenCalled();
+    const ctrl = makeMockController();
+    ctrl.nodeDrag.state = {};
+    // @ts-ignore
+    onNodeDragEnd(ctrl, { id: "idk", description: "ok" }, { x: 0, y: 0 });
+    expect(ctrl.backend.createLink).not.toHaveBeenCalled();
   });
   it("shoud do same as openCreateLinkPopUp, with default values for links from interimLink", async () => {
     const ctrl = makeMockController();

--- a/src/GraphManager/GraphEdit.testingutil.tsx
+++ b/src/GraphManager/GraphEdit.testingutil.tsx
@@ -53,6 +53,7 @@ export const makeMockController = () => {
     forceGraphRef: {
       current: forceGraphMethods,
     },
+    setCooldownTicks: jest.fn().mockName("setCooldownTicks"),
     nodeDrag: {
       setState: jest.fn(),
       state: {},

--- a/src/GraphManager/GraphEdit.tsx
+++ b/src/GraphManager/GraphEdit.tsx
@@ -22,14 +22,29 @@ import { DeleteEdgeFn } from "./hooks/useDeleteEdge";
 import { HasID, ZoomState } from "./Zoom";
 import i18n from "src/i18n";
 
+// Note: must be kept constant for all times, otherwise database must be
+// migrated to a new maximum weight.
 export const MAX_LINK_WEIGHT = 10;
+
+// Default value for creating new links.
 export const DEFAULT_EDIT_LINK_WEIGHT = MAX_LINK_WEIGHT / 2;
+
+// See https://github.com/vasturiano/force-graph -> cooldownTicks
 export const FG_ENGINE_COOLDOWN_TICKS_DEFAULT = 1000;
 export const FG_ENGINE_COOLDOWN_TICKS_DISABLED = 0;
 
-const NODE_DRAG_SNAP_IN_OUT_DISTANCES = [25, 35];
-export const DRAG_snapInDistanceSquared = Math.pow(NODE_DRAG_SNAP_IN_OUT_DISTANCES[0], 2);
-export const DRAG_snapOutDistanceSquared = Math.pow(NODE_DRAG_SNAP_IN_OUT_DISTANCES[1], 2);
+// onNodeDrag: snap's to the node if distance < this[0], un-snaps if distance > this[1]
+const NODE_DRAG_SNAP_IN_OUT_DISTANCES = [35, 45];
+export const DRAG_snapInDistanceSquared = Math.pow(
+  NODE_DRAG_SNAP_IN_OUT_DISTANCES[0],
+  2,
+);
+export const DRAG_snapOutDistanceSquared = Math.pow(
+  NODE_DRAG_SNAP_IN_OUT_DISTANCES[1],
+  2,
+);
+
+// Temporary link ID for link creation via node-dragging (onNodeDrag).
 export const INTERIM_TMP_LINK_ID = "INTERIM_TMP";
 
 export interface GraphState {
@@ -211,7 +226,9 @@ export const onNodeDrag = (
     if (
       nodeDrag.interimLink !== undefined &&
       node !== nodeDrag.interimLink.target &&
-      distanceSquared(dragSourceNode, node) < DRAG_snapInDistanceSquared
+      distanceSquared(dragSourceNode, node) < DRAG_snapInDistanceSquared &&
+      distanceSquared(dragSourceNode, node) <
+        distanceSquared(dragSourceNode, nodeDrag.interimLink.target)
     ) {
       newInterimLinkTarget = node;
     }

--- a/src/GraphManager/GraphEditPopUp.tsx
+++ b/src/GraphManager/GraphEditPopUp.tsx
@@ -27,6 +27,9 @@ import * as yup from "yup";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/system";
 
+const MIN_NODE_DESCRIPTION_LENGTH = 2; // note: for chinese words, 2 characters is already precise
+const MAX_NODE_DESCRIPTION_LENGTH = 40;
+
 interface LinkWeightSliderProps {
   defaultValue: number;
   setSliderValue: React.Dispatch<React.SetStateAction<Number | Array<Number>>>;
@@ -320,7 +323,10 @@ const LinkVotePopUp = ({ handleClose, ctrl }: SubGraphEditPopUpProps) => {
 };
 
 export const nodeValidation = yup.object({
-  nodeDescription: yup.string().min(4).max(40),
+  nodeDescription: yup
+    .string()
+    .min(MIN_NODE_DESCRIPTION_LENGTH)
+    .max(MAX_NODE_DESCRIPTION_LENGTH),
 });
 
 const NodeEditPopUp = ({ handleClose, ctrl }: SubGraphEditPopUpProps) => {

--- a/src/GraphManager/GraphRenderer.tsx
+++ b/src/GraphManager/GraphRenderer.tsx
@@ -30,6 +30,7 @@ import {
   makeOnLinkClick,
   makeOnNodeClick,
   Backend,
+  FG_ENGINE_COOLDOWN_TICKS_DEFAULT,
 } from "./GraphEdit";
 import { GraphEditPopUp, GraphEditPopUpState } from "./GraphEditPopUp";
 import { useCreateNode } from "./hooks/useCreateNode";
@@ -508,6 +509,9 @@ export const GraphRenderer = (props: GraphRendererProps) => {
     deleteNode,
     deleteLink: deleteEdge,
   };
+  const [cooldownTicks, setCooldownTicks] = useState(
+    FG_ENGINE_COOLDOWN_TICKS_DEFAULT,
+  );
   const controller: Controller = {
     backend,
     popUp: {
@@ -516,6 +520,7 @@ export const GraphRenderer = (props: GraphRendererProps) => {
     },
     graph: makeGraphState(graph, setGraph, performInitialZoom),
     forceGraphRef: props.forceGraphRef,
+    setCooldownTicks,
     nodeDrag: {
       state: nodeDrag,
       setState: setNodeDrag,
@@ -606,6 +611,7 @@ export const GraphRenderer = (props: GraphRendererProps) => {
         width={availableSpace.width}
         ref={props.forceGraphRef}
         graphData={graph}
+        cooldownTicks={cooldownTicks}
         nodeCanvasObject={makeNodeCanvasObject(controller)}
         nodePointerAreaPaint={nodePointerAreaPaint}
         onNodeClick={makeOnNodeClick(controller)}


### PR DESCRIPTION
- stop simulation when onNodeDrag starts, this results in better UX, since nodes no longer float away, while you're trying to attach a link to them (using this approach https://github.com/vasturiano/react-force-graph/issues/124)
- only change target node for onNodeDrag if the new node is closer than the current node, again way better UX, since the link no longer unexpectedly switches, while you thought you already selected the right target
- change minimum node-description length to 2 characters, since in chinese 2 characters can uniquely describe a thing (optimally this would be language dependent in the frontend, backend has no restrictions here, which is good imo)