### PR TITLE
feat: 2 modes: graph-interaction & editing-enabled

### DIFF
--- a/src/GraphManager/GraphEdit/GraphEdit.testingutil.tsx
+++ b/src/GraphManager/GraphEdit/GraphEdit.testingutil.tsx
@@ -85,8 +85,10 @@ export const makeMockController = () => {
       setShiftHeld: jest.fn(),
     },
     mode: {
-      isEditMode: false,
-      setIsEditMode: jest.fn(),
+      isEditingEnabled: false,
+      setIsEditingEnabled: jest.fn(),
+      allowGraphInteractions: false,
+      setAllowGraphInteractions: jest.fn(),
     },
   };
   return ctrl;

--- a/src/GraphManager/GraphEdit/GraphEdit.tsx
+++ b/src/GraphManager/GraphEdit/GraphEdit.tsx
@@ -158,8 +158,10 @@ export interface SearchState {
 }
 
 export interface ModeState {
-  isEditMode: boolean;
-  setIsEditMode: Dispatch<SetStateAction<boolean>>;
+  isEditingEnabled: boolean;
+  setIsEditingEnabled: Dispatch<SetStateAction<boolean>>;
+  allowGraphInteractions: boolean;
+  setAllowGraphInteractions: Dispatch<SetStateAction<boolean>>;
 }
 
 export interface Controller {

--- a/src/GraphManager/GraphEdit/MarkdownField.tsx
+++ b/src/GraphManager/GraphEdit/MarkdownField.tsx
@@ -48,8 +48,7 @@ export interface MarkdownConfig {
   fieldLabel: string;
   initialMarkdownContent: string;
   setValueOnChange: (markdown: string) => void;
-  // unused for the current markdown editor, it is always multiline
-  multiline?: boolean;
+  isEditingEnabled: boolean;
 }
 interface MarkdownEditorConfig extends MarkdownConfig {
   isEmpty: boolean;
@@ -61,22 +60,24 @@ interface MarkdownEditorConfig extends MarkdownConfig {
   onClickStateChange: number;
 }
 
-const FocusWhenStateChangePlugin = ({
-  onClickStateChange,
-}: {
+const FocusWhenStateChangePlugin = (props: {
   onClickStateChange: number;
+  isEditingEnabled: boolean;
 }) => {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
-    if (onClickStateChange === 0) {
+    if (props.onClickStateChange === 0) {
       editor.setEditable(false);
+      return;
+    }
+    if (!props.isEditingEnabled) {
       return;
     }
     editor.setEditable(true);
     // XXX(skep): if this timeout hack is not used the user would have to click
     // 2 times, which is confusing, but why is it needed?!
     setTimeout(() => editor.focus(), 10);
-  }, [onClickStateChange]);
+  }, [props.onClickStateChange]);
   return null;
 };
 
@@ -135,6 +136,7 @@ const MarkdownEditor = (props: MarkdownEditorConfig) => {
         <HistoryPlugin />
         <FocusWhenStateChangePlugin
           onClickStateChange={props.onClickStateChange}
+          isEditingEnabled={props.isEditingEnabled}
         />
       </LexicalComposer>
       <NotchedOutline
@@ -151,6 +153,9 @@ export const MarkdownEditorWrapper = (props: MarkdownConfig) => {
   const [onClickStateChange, setOnClickStateChange] = useState(0);
   const handleClick: MouseEventHandler<HTMLDivElement> = (_) => {
     setOnClickStateChange(1);
+    if (!props.isEditingEnabled) {
+      return;
+    }
     setIsFocused(true);
   };
   const handleUnfocus = () => {

--- a/src/GraphManager/GraphEdit/ModeButton.tsx
+++ b/src/GraphManager/GraphEdit/ModeButton.tsx
@@ -2,25 +2,18 @@ import EditIcon from "@mui/icons-material/Edit";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import Button from "@mui/material/Button";
 
-import { useUserDataContext } from "@src/UserDataContext";
-import i18n from "@src/i18n";
 import { Controller } from "./GraphEdit";
 import { CircleContainer } from "./CreateButton";
 
 export const EditModeButton = ({ ctrl }: { ctrl: Controller }) => {
-  const { userID } = useUserDataContext();
   const iconProp = { fontSize: 40 };
   const onClick = () => {
-    if (!userID) {
-      alert(i18n.t("To edit the graph please login."));
-      return;
-    }
-    ctrl.mode.setIsEditMode(!ctrl.mode.isEditMode);
+    ctrl.mode.setAllowGraphInteractions(!ctrl.mode.allowGraphInteractions);
   };
   return (
     <Button id="basic-button" onClick={onClick}>
       <CircleContainer>
-        {ctrl.mode.isEditMode ? (
+        {ctrl.mode.allowGraphInteractions ? (
           <EditIcon style={iconProp} />
         ) : (
           <VisibilityIcon style={iconProp} />

--- a/src/GraphManager/GraphEdit/PopUp.tsx
+++ b/src/GraphManager/GraphEdit/PopUp.tsx
@@ -289,6 +289,7 @@ export const LinkCreatePopUp = ({
       handleClose={extendedHandleClose}
       fields={fields}
       formik={formik}
+      isEditingEnabled={ctrl.mode.isEditingEnabled}
     />
   );
 };
@@ -327,6 +328,7 @@ const LinkVotePopUp = ({ handleClose, ctrl }: SubGraphEditPopUpProps) => {
       fields={fields}
       formik={formik}
       onDelete={ctrl.popUp.state.linkVote?.onDelete}
+      isEditingEnabled={ctrl.mode.isEditingEnabled}
     />
   );
 };
@@ -361,6 +363,7 @@ const NodeEditPopUp = ({ handleClose, ctrl }: SubGraphEditPopUpProps) => {
       fieldName="nodeDescription"
       fieldLabel={t("Node Description")}
       formik={formik}
+      disabled={!ctrl.mode.isEditingEnabled}
       autoFocus
     />,
     <MarkdownEditorWrapper
@@ -371,7 +374,7 @@ const NodeEditPopUp = ({ handleClose, ctrl }: SubGraphEditPopUpProps) => {
         const helpers = formik.getFieldHelpers("nodeResources");
         helpers.setValue(markdown);
       }}
-      multiline={true}
+      isEditingEnabled={ctrl.mode.isEditingEnabled}
     />,
   ];
   return (
@@ -382,6 +385,7 @@ const NodeEditPopUp = ({ handleClose, ctrl }: SubGraphEditPopUpProps) => {
       fields={fields}
       formik={formik}
       onDelete={ctrl.popUp.state.nodeEdit?.onDelete}
+      isEditingEnabled={ctrl.mode.isEditingEnabled}
     />
   );
 };
@@ -391,6 +395,7 @@ type DraggableFormPorops = SubGraphEditPopUpProps & {
   fields: any;
   formik: { submitForm: () => void };
   onDelete?: () => void;
+  isEditingEnabled: boolean;
 };
 
 export const DraggableForm = (props: DraggableFormPorops) => {
@@ -423,7 +428,12 @@ export const DraggableForm = (props: DraggableFormPorops) => {
             </Button>
           </Tooltip>
           {!!props.onDelete && (
-            <Button variant="contained" color="warning" onClick={onDelete}>
+            <Button
+              variant="contained"
+              color="warning"
+              onClick={onDelete}
+              disabled={!props.isEditingEnabled}
+            >
               {t("Delete")}
             </Button>
           )}
@@ -432,6 +442,7 @@ export const DraggableForm = (props: DraggableFormPorops) => {
               variant="contained"
               color="primary"
               onClick={() => props.formik.submitForm()}
+              disabled={!props.isEditingEnabled}
             >
               {t("Save")}
             </Button>

--- a/src/GraphManager/GraphRenderer.tsx
+++ b/src/GraphManager/GraphRenderer.tsx
@@ -94,7 +94,13 @@ const makeNodePointerAreaPaint = (ctrl: Controller) => {
     ctx: CanvasRenderingContext2D,
     globalScale: number,
   ) => {
-    nodePointerAreaPaint(node, color, ctx, globalScale, ctrl.mode.isEditMode);
+    nodePointerAreaPaint(
+      node,
+      color,
+      ctx,
+      globalScale,
+      ctrl.mode.allowGraphInteractions,
+    );
   };
 };
 
@@ -178,7 +184,7 @@ export const GraphRenderer = (props: GraphRendererProps) => {
     makeInitialGraphData(),
   );
   const performInitialZoom = useRef(false);
-  const { language } = useUserDataContext();
+  const { language, userID } = useUserDataContext();
   const { data: graphDataFromBackend } = useGraphData();
   const [shiftHeld, setShiftHeld] = useState(false);
   const downHandler = ({ key }: any) => {
@@ -226,7 +232,8 @@ export const GraphRenderer = (props: GraphRendererProps) => {
     new Set<ForceGraphNodeObject>(),
   );
 
-  const [isEditMode, setIsEditMode] = useState(false);
+  const [isEditingEnabled, setIsEditingEnabled] = useState(false);
+  const [allowGraphInteractions, setAllowGraphInteractions] = useState(false);
   const controller: Controller = {
     backend,
     popUp: {
@@ -258,7 +265,12 @@ export const GraphRenderer = (props: GraphRendererProps) => {
       zoomState,
       setZoomState,
     },
-    mode: { isEditMode, setIsEditMode },
+    mode: {
+      isEditingEnabled,
+      setIsEditingEnabled,
+      allowGraphInteractions,
+      setAllowGraphInteractions,
+    },
   };
   const zoomControl = makeZoomControl(controller);
   controller.zoom.setUserZoomLevel = zoomControl.onZoomChange;
@@ -323,6 +335,14 @@ export const GraphRenderer = (props: GraphRendererProps) => {
       window.removeEventListener("resize", handleResize);
     };
   }, []);
+  useEffect(() => {
+    console.log(userID);
+    if (userID) {
+      controller.mode.setIsEditingEnabled(true);
+    } else {
+      controller.mode.setIsEditingEnabled(false);
+    }
+  }, [userID]);
   return (
     <>
       <SmallAlignBottomLargeAlignLeft

--- a/src/GraphManager/utils.test.ts
+++ b/src/GraphManager/utils.test.ts
@@ -306,7 +306,7 @@ describe("linkPointerAreaPaint", () => {
   it("should draw in edit mode", () => {
     const { ctx } = makeCanvasRenderingContext2D();
     const ctrl = makeMockController();
-    ctrl.mode.isEditMode = true;
+    ctrl.mode.allowGraphInteractions = true;
     linkPointerAreaPaint(
       // @ts-ignore
       ctrl,
@@ -320,7 +320,7 @@ describe("linkPointerAreaPaint", () => {
   it("should not draw when not in edit mode", () => {
     const { ctx } = makeCanvasRenderingContext2D();
     const ctrl = makeMockController();
-    ctrl.mode.isEditMode = false;
+    ctrl.mode.isEditingEnabled = false;
     linkPointerAreaPaint(
       // @ts-ignore
       ctrl,

--- a/src/GraphManager/utils.ts
+++ b/src/GraphManager/utils.ts
@@ -315,7 +315,7 @@ export const linkPointerAreaPaint = (
   ctx: CanvasRenderingContext2D,
   globalScale: number,
 ) => {
-  if (!ctrl.mode.isEditMode) {
+  if (!ctrl.mode.allowGraphInteractions) {
     return;
   }
   drawLinkLine({ ctrl, link, ctx, globalScale, color: invisibleTouchPaint });

--- a/src/shared/Styles.tsx
+++ b/src/shared/Styles.tsx
@@ -17,6 +17,7 @@ export interface TextFieldConfig<T extends FormikValues> {
   fieldLabel: string;
   autoFocus?: boolean;
   multiline?: boolean;
+  disabled?: boolean;
 }
 
 const TextFieldFormikGeneratorInternal = <T extends FormikValues>(
@@ -44,6 +45,7 @@ const TextFieldFormikGeneratorInternal = <T extends FormikValues>(
       }
       autoFocus={props.autoFocus ?? false}
       multiline={props.multiline ?? false}
+      disabled={props.disabled ?? false}
     />
   );
 };


### PR DESCRIPTION
Removes the edit-mode, that would only check if the user is logged in, and replaces it with 2 modes: {allowGraphInteractions, isEditingEnabled}.
Every user (even without login) can change if graph-interactions should happen.
Only logged in user can edit the graph (i.e. buttons are disabled otherwise).