### PR TITLE
feat: add user avatar group in node-edit menu

### DIFF
--- a/src/GraphManager/hooks/types.ts
+++ b/src/GraphManager/hooks/types.ts
@@ -25,3 +25,15 @@ export interface Text {
 export interface Status {
   Message: string;
 }
+
+export enum NodeEditType {
+  create = "create",
+  edit = "edit",
+}
+export interface NodeEdit {
+  username: string;
+  type: NodeEditType;
+  //newDescription: string
+  //newResources?: string
+  updatedAt: Date;
+}

--- a/src/GraphManager/hooks/useNodeEdits.ts
+++ b/src/GraphManager/hooks/useNodeEdits.ts
@@ -1,0 +1,28 @@
+import { gql, useQuery } from "@apollo/client";
+import { ApolloQueryResponse, NodeEdit } from "./types";
+
+const GET_NODE_EDITS = gql`
+  query nodeEdits($nodeID: ID!) {
+    nodeEdits(nodeID: $nodeID) {
+      username
+      type
+      updatedAt
+    }
+  }
+`;
+// unused nodeEdit fields:
+//      newDescription
+//      newResources
+
+export interface NodeEditsResponse {
+  data: { nodeEdits: NodeEdit[] };
+  queryResponse: ApolloQueryResponse;
+}
+
+export function useNodeEdits(nodeID: string): NodeEditsResponse {
+  const { loading, data, error, networkStatus } = useQuery(GET_NODE_EDITS, {
+    variables: { nodeID: nodeID },
+  });
+
+  return { data, queryResponse: { loading, error, networkStatus } };
+}


### PR DESCRIPTION
- query node-edits when edit menu is opened
- display node-creator and editors in a nice <AvatarGroup/>